### PR TITLE
Patch 1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if(PNGW_INSTALL)
     )
     write_basic_package_version_file(
         "${PROJECT_BINARY_DIR}/pngwConfigVersion.cmake"
-        VERSION 1.0.0
+        VERSION 1.0.1
         COMPATIBILITY SameMajorVersion
     )
     include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ PROJECT(pngw
 )
 option(PNGW_BUILD_EXAMPLE "Build the png_wrapper.h example project" OFF)
 option(PNGW_EXAMPLE_AUTO_FETCH "Automatically fetch the dependencies of the png_wrapper.h example project" OFF)
-option(PNGW_INSTALL "Generate the png_wrapper.h installation target." ON)
 add_library(${PROJECT_NAME} INTERFACE "")
 add_library(pngw::pngw ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
@@ -37,26 +36,3 @@ target_include_directories(${PROJECT_NAME}
 if(PNGW_BUILD_EXAMPLE)
     add_subdirectory(example)
 endif()
-if(PNGW_INSTALL)
-    include(CMakePackageConfigHelpers)
-    configure_package_config_file(
-        pngw-config.cmake.in
-    )
-    write_basic_package_version_file(
-        "${PROJECT_BINARY_DIR}/pngwConfigVersion.cmake"
-        VERSION 1.0.1
-        COMPATIBILITY SameMajorVersion
-    )
-    include(GNUInstallDirs)
-    install(TARGETS pngw
-        EXPORT pngwTargets
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-            COMPONENT          pngw_Development
-    )
-    install(EXPORT pngwTargets DESTINATION lib/cmake/mylib)
-    install(
-        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include"
-        DESTINATION "${CMAKE_INSTALL_LINCUDEDIR}"
-    )
-endif()
-

--- a/include/pngw/png_wrapper.h
+++ b/include/pngw/png_wrapper.h
@@ -593,7 +593,7 @@ extern "C"
       png_const_bytep row_start = data + (y * actual_row_offset);
       png_write_row(png_ptr, row_start);
     }
-    png_write_end(png_ptr, NULL);
+    png_write_end(png_ptr, info_ptr);
     png_destroy_write_struct(&png_ptr, &info_ptr, NULL);
     fclose(f);
     png_destroy_write_struct(&png_ptr, &info_ptr);

--- a/include/pngw/png_wrapper.h
+++ b/include/pngw/png_wrapper.h
@@ -561,14 +561,14 @@ extern "C"
     if (!info_ptr)
     {
       fclose(f);
-      png_destroy_read_struct(&png_ptr, NULL, NULL);
+      png_destroy_write_struct(&png_ptr, NULL, NULL);
       return PNGW_RESULT_ERROR_OUT_OF_MEMORY;
     }
     /* Create jump buffer to handle errors */
     if (setjmp(png_jmpbuf(png_ptr)))
     {
       fclose(f);
-      png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+      png_destroy_write_struct(&png_ptr, &info_ptr, NULL);
       return PNGW_RESULT_ERROR_JUMP_BUFFER_CALLED;
     }
     const int png_color_type = pngwColorToPngColor(color);

--- a/include/pngw/png_wrapper.h
+++ b/include/pngw/png_wrapper.h
@@ -594,6 +594,7 @@ extern "C"
       png_write_row(png_ptr, row_start);
     }
     png_write_end(png_ptr, NULL);
+    png_destroy_write_struct(&png_ptr, &info_ptr, NULL);
     fclose(f);
     png_destroy_write_struct(&png_ptr, &info_ptr);
     return PNGW_RESULT_OK;


### PR DESCRIPTION
* Fix invalid libpng function signatures in `pngwWriteFile()`.
* End writing correctly in `pngwWriteFile()` and destroy all libpng structures to prevent a memory leak.
* Remove the broken CMake installation target.