### PR TITLE
(the actual) Patch 1.0.1

### DIFF
--- a/include/pngw/png_wrapper.h
+++ b/include/pngw/png_wrapper.h
@@ -21,7 +21,7 @@
 */
 
 /*
-   png_wrapper.h v1.0.0
+   png_wrapper.h v1.0.1
    Easy to use wrapper arround libpng
    The source for this library can be found on GitHub:
    https://github.com/Journeyman-dev/png_wrapper.h


### PR DESCRIPTION
Had to redo this pull request because I forgot to update the version number in the png_wrapper.h file.

* Fix invalid libpng function signatures in `pngwWriteFile()`.
* End writing correctly in `pngwWriteFile()` and destroy all libpng structures to prevent a memory leak.
* Remove the broken CMake installation target.wups.